### PR TITLE
Add support for configuring request credential preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ chunkedRequest({
   method: 'POST',
   headers: { /*...*/ },
   body: JSON.stringify({ /*...*/ }),
+  credentials: 'include',
   chunkParser(rawChunk) { /*...*/ },
   onChunk(err, parsedChunk) { /*...*/ },
   onComplete(result) { /*...*/ }
@@ -43,6 +44,9 @@ A hash of HTTP headers to sent with the request.
 
 #### body (optional)
 The value to send along with the request.
+
+#### credentials (optional)
+Determine if HTTP cookies will be sent along with the request, one of `same-origin`, `include` or `omit` (mirroring the fetch API).  Defaults to `same-domain` for consistency between fetch and XHR based transport; note that a value of `omit` will not affect XHR based transports which will always send cookies with requests made against the same origin.
 
 #### chunkParser (optional) 
 A function which implements the following interface:
@@ -85,7 +89,7 @@ Note that the `onChunk` option should be used to process the incoming response b
 A function which implements the following interface:
 
 ```js
-({ url, headers, method, body, onComplete, onRawChunk }) => undefined
+({ url, headers, method, body, credentials, onComplete, onRawChunk }) => undefined
 ```
 
 The underlying function to use to make the request, see the provided implementations if you wish to provide a custom extension.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "cookie": "^0.2.3",
     "eslint": "^2.4.0",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -4,7 +4,7 @@ export const READABLE_BYTE_STREAM = 'readable-byte-stream';
 
 export default function fetchRequest(options) {
   const decoder = new TextDecoder();
-  const { onRawChunk, onComplete, method, body } = options;
+  const { onRawChunk, onComplete, method, body, credentials } = options;
   const headers = marshallHeaders(options.headers);
 
   function pump(reader, res) {
@@ -22,7 +22,7 @@ export default function fetchRequest(options) {
       });
   }
 
-  fetch(options.url, { headers, method, body })
+  fetch(options.url, { headers, method, body, credentials })
     .then(res => pump(res.body.getReader(), res));
 }
 

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -29,6 +29,9 @@ export default function mozXhrRequest(options) {
       xhr.setRequestHeader(k, options.headers[k]);
     })
   }
+  if (options.credentials === 'include') {
+    xhr.withCredentials = true;
+  }
   xhr.addEventListener('progress', onProgressEvent);
   xhr.addEventListener('load', onLoadEvent);
   xhr.send(options.body);

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -25,6 +25,9 @@ export default function xhrRequest(options) {
       xhr.setRequestHeader(k, options.headers[k]);
     })
   }
+  if (options.credentials === 'include') {
+    xhr.withCredentials = true;
+  }
   xhr.addEventListener('progress', onProgressEvent);
   xhr.addEventListener('load', onLoadEvent);
   xhr.send(options.body);

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default function chunkedRequest(options) {
     headers,
     method = 'GET',
     body,
+    credentials = 'same-origin',
     onComplete = noop,
     onChunk = noop,
     chunkParser = defaultChunkParser
@@ -48,6 +49,7 @@ export default function chunkedRequest(options) {
     headers,
     method,
     body,
+    credentials,
     onComplete,
     onRawChunk: processRawChunk
   });

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -2,6 +2,7 @@
 
 const http = require('http');
 const url = require('url');
+const cookieParser = require('cookie');
 
 // Which port should HTTP traffic be served over?
 const httpPort = process.env.HTTP_PORT || 2001;
@@ -38,6 +39,7 @@ function serveEchoResponse(req, res) {
     res.write(JSON.stringify({
       headers: req.headers,
       method: req.method,
+      cookies: cookieParser.parse(req.headers.cookie || ''),
       body
     }) + "\n");
     res.end();


### PR DESCRIPTION
Mirror the fetch API; set the `withCredentials` flag accordingly for XHR-based transports.

Fixes #5, cc @ajselvig
