### PR TITLE
remove window for web worker compatibility

### DIFF
--- a/src/defaultTransportFactory.js
+++ b/src/defaultTransportFactory.js
@@ -6,7 +6,7 @@ let selected = null;
 
 export default function defaultTransportFactory() {
   if (!selected) {
-    if (typeof window.ReadableByteStream === 'function') {
+    if (typeof ReadableByteStream === 'function') {
       selected = fetchRequest;
     } else if (navigator.userAgent.toLowerCase().indexOf('firefox') !== -1) {
       selected = mozXhrRequest;


### PR DESCRIPTION
For web workers, `ReadableByteStream` is available, but `window.ReadableByteStream` is not, which makes this library fail in a web worker.
