### PR TITLE
Fix ReadableStream detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 You can leverage [chunked-transfer](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) encoded responses on your service tier to provide partial responses to the client before the entire response has been sent.
 
-At the time of writing (Feb 2016) there is fragmented support for efficient chunked transfer encoding in Javascript with `moz-chunked-text` provided only in Firefox and `ReadableByteStream` support only present in Chrome.  Other browsers need to fall-back to substring'ing the `responseText` property when the XHR's readyState event is fired.
+At the time of writing (August 2016) there is fragmented support for efficient chunked transfer encoding in Javascript with `moz-chunked-text` provided only in Firefox and `ReadableStream` support only present in Chrome.  Other browsers need to fall-back to substring'ing the `responseText` property when the XHR's readyState event is fired.
 
 This library aims to smooth over the available implementations and provide a consistent API for dealing with cross-browser support.
 

--- a/src/defaultTransportFactory.js
+++ b/src/defaultTransportFactory.js
@@ -5,10 +5,12 @@ import xhrRequest from './impl/xhr';
 let selected = null;
 
 export default function defaultTransportFactory() {
+  const userAgent = navigator.userAgent.toLowerCase();
+
   if (!selected) {
-    if (typeof ReadableByteStream === 'function') {
+    if (userAgent.indexOf("chrome") !== -1) {
       selected = fetchRequest;
-    } else if (navigator.userAgent.toLowerCase().indexOf('firefox') !== -1) {
+    } else if (userAgent.indexOf('firefox') !== -1) {
       selected = mozXhrRequest;
     } else {
       selected = xhrRequest;


### PR DESCRIPTION
Chrome dropped the `ReadableByteStrem` constructor function a few releases back; instead of adding another brittle detection; I've just settled on sniffing the user agent (same as we do for firefox) and detect chrome... _sigh_
