### PR TITLE
Add support for binary data (#12)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
     "no-var": 2,
     "prefer-const": 2
   },
+  "env": {
+    "browser": true
+  },
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,11 @@
   "env": {
     "browser": true
   },
+  "globals": {
+    "Uint8Array": false,
+    "TextEncoder": false,
+    "TextDecoder": false
+  },
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ $ npm install chunked-request
 
 or as a standalone ES5 browser script by obtaining `dist/chunked-request.js` from a [tagged release](https://github.com/jonnyreeves/chunked-request/releases).
 
+## Browser Support
+This library is tested against IE 10, Safari, Firefox and Chrome.  It relies on browser support for [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) and [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder) Browser APIs; for legacy environments such as Safari and IE10, you will need to supply one or more of the polyfills listed below:
+
+* [TextEncoder / TextDecoder Polyfill](https://www.npmjs.com/package/text-encoding) (IE10, Safari)
+* [TypedArray](https://github.com/inexorabletash/polyfill/blob/master/typedarray.js) (IE10)
+
 ## API
 
 ```js

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ or as a standalone ES5 browser script by obtaining `dist/chunked-request.js` fro
 This library is tested against IE 10, Safari, Firefox and Chrome.  It relies on browser support for [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) and [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder) Browser APIs; for legacy environments such as Safari and IE10, you will need to supply one or more of the polyfills listed below:
 
 * [TextEncoder / TextDecoder Polyfill](https://www.npmjs.com/package/text-encoding) (IE10, Safari)
-* [TypedArray](https://github.com/inexorabletash/polyfill/blob/master/typedarray.js) (IE10)
 
 ## API
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -68,6 +68,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'node_modules/text-encoding/lib/encoding.js',
       'build/integration-tests.js'
     ],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -78,6 +78,7 @@ module.exports = function(config) {
 
     proxies: {
       '/chunked-response': 'http://localhost:2001/chunked-response',
+      '/chunked-utf8-response': 'http://localhost:2001/chunked-utf8-response',
       '/split-chunked-response': 'http://localhost:2001/split-chunked-response',
       '/error-response': 'http://localhost:2001/error-response',
       '/echo-response': 'http://localhost:2001/echo-response'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "karma-sauce-launcher": "^1.0.0",
     "lodash": "^4.15.0",
     "text-encoding": "^0.6.0",
-    "typedarray": "0.0.6",
     "url": "^0.11.0"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "karma-jasmine": "^1.0.2",
     "karma-sauce-launcher": "^1.0.0",
     "lodash": "^4.15.0",
+    "text-encoding": "^0.6.0",
+    "typedarray": "0.0.6",
     "url": "^0.11.0"
   },
-  "dependencies": {
-    "utf-8": "^1.0.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
   "jsnext:main": "src/index.js",
   "repository": "https://github.com/jonnyreeves/chunked-request",
   "license": "MIT",
-  "keywords": [ "request", "chunked", "transfer", "comet", "xhr", "fetch" ],
+  "keywords": [
+    "request",
+    "chunked",
+    "transfer",
+    "comet",
+    "xhr",
+    "fetch"
+  ],
   "scripts": {
     "prepublish": "npm run clean && npm run build:lib",
     "clean": "rm -rf build/*",
@@ -17,19 +24,22 @@
     "release": "./release.sh ${npm_package_version}"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.2.0",
-    "browserify": "^13.0.0",
-    "cookie": "^0.2.3",
-    "eslint": "^2.4.0",
+    "babel-cli": "^6.11.4",
+    "babel-preset-es2015": "^6.13.2",
+    "babelify": "^7.3.0",
+    "browserify": "^13.1.0",
+    "cookie": "^0.3.1",
+    "eslint": "^3.3.1",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
-    "karma": "^0.13.22",
-    "karma-chrome-launcher": "^0.2.2",
-    "karma-jasmine": "^0.3.8",
-    "karma-sauce-launcher": "^0.3.1",
-    "lodash": "^4.6.1",
+    "karma": "^1.2.0",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-sauce-launcher": "^1.0.0",
+    "lodash": "^4.15.0",
     "url": "^0.11.0"
+  },
+  "dependencies": {
+    "utf-8": "^1.0.0"
   }
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,9 +1,4 @@
 {
-  "globals": {
-    "Uint8Array": false,
-    "TextEncoder": false,
-    "TextDecoder": false
-  },
   "rules": {
     "no-var": 2
   }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,9 +1,8 @@
 {
-  "env": {
-    "browser": true
-  },
   "globals": {
-    "Uint8Array": false
+    "Uint8Array": false,
+    "TextEncoder": false,
+    "TextDecoder": false
   },
   "rules": {
     "no-var": 2

--- a/src/defaultChunkParser.js
+++ b/src/defaultChunkParser.js
@@ -1,28 +1,33 @@
+import { getStringFromBytes } from 'utf-8';
+
 const entryDelimiter = '\n';
 
 // The defaultChunkParser expects the response from the server to consist of new-line
 // delimited JSON, eg:
 //
-//  { "chunk": "#1", "data": "Hello" }
+//  { "chunk": "#1", "data": "Hello" }\n
 //  { "chunk": "#2", "data": "World" }
 //
 // It will correctly handle the case where a chunk is emitted by the server across
 // delimiter boundaries.
-export default function defaultChunkParser(rawChunk, prevChunkSuffix = '', isFinalChunk = false) {
-  let chunkSuffix;
-
-  const rawChunks = `${prevChunkSuffix}${rawChunk}`
-    .split(entryDelimiter);
-
-  if (!isFinalChunk && !hasSuffix(rawChunk, entryDelimiter)) {
-    chunkSuffix = rawChunks.pop();
+export default function defaultChunkParser(bytes, state = {}, flush = false) {
+  const chunkStr = getStringFromBytes(bytes, 0, undefined, true);
+  const jsonLiterals = chunkStr.split(entryDelimiter);
+  if (state.trailer) {
+    jsonLiterals[0] = `${state.trailer}${jsonLiterals[0]}`;
   }
 
-  const processedChunks = rawChunks
+  // Is this a complete message?  If not; push the trailing (incomplete) string 
+  // into the state. 
+  if (!flush && !hasSuffix(chunkStr, entryDelimiter)) {
+    state.trailer = jsonLiterals.pop();
+  }
+
+  const jsonObjects = jsonLiterals
     .filter(v => v.trim() !== '')
     .map(v => JSON.parse(v));
 
-  return [ processedChunks, chunkSuffix ];
+  return [ jsonObjects, state ];
 }
 
 function hasSuffix(s, suffix) {

--- a/src/defaultChunkParser.js
+++ b/src/defaultChunkParser.js
@@ -1,4 +1,4 @@
-import { getStringFromBytes } from 'utf-8';
+import { stringFromUint8Array } from './util';
 
 const entryDelimiter = '\n';
 
@@ -11,7 +11,7 @@ const entryDelimiter = '\n';
 // It will correctly handle the case where a chunk is emitted by the server across
 // delimiter boundaries.
 export default function defaultChunkParser(bytes, state = {}, flush = false) {
-  const chunkStr = getStringFromBytes(bytes, 0, undefined, true);
+  const chunkStr = stringFromUint8Array(bytes);
   const jsonLiterals = chunkStr.split(entryDelimiter);
   if (state.trailer) {
     jsonLiterals[0] = `${state.trailer}${jsonLiterals[0]}`;

--- a/src/defaultChunkParser.js
+++ b/src/defaultChunkParser.js
@@ -1,5 +1,3 @@
-import { stringFromUint8Array } from './util';
-
 const entryDelimiter = '\n';
 
 // The defaultChunkParser expects the response from the server to consist of new-line
@@ -11,10 +9,15 @@ const entryDelimiter = '\n';
 // It will correctly handle the case where a chunk is emitted by the server across
 // delimiter boundaries.
 export default function defaultChunkParser(bytes, state = {}, flush = false) {
-  const chunkStr = stringFromUint8Array(bytes);
+  if (!state.textDecoder) {
+    state.textDecoder = new TextDecoder();
+  }
+  const textDecoder = state.textDecoder;
+  const chunkStr = textDecoder.decode(bytes, { stream: !flush })
   const jsonLiterals = chunkStr.split(entryDelimiter);
   if (state.trailer) {
     jsonLiterals[0] = `${state.trailer}${jsonLiterals[0]}`;
+    state.trailer = '';
   }
 
   // Is this a complete message?  If not; push the trailing (incomplete) string 

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -3,7 +3,6 @@ import { isObject } from '../util';
 export const READABLE_BYTE_STREAM = 'readable-byte-stream';
 
 export default function fetchRequest(options) {
-  const decoder = new TextDecoder();
   const { onRawChunk, onRawComplete, method, body, credentials } = options;
   const headers = marshallHeaders(options.headers);
 
@@ -17,7 +16,7 @@ export default function fetchRequest(options) {
             raw: res
           });
         }
-        onRawChunk(decoder.decode(result.value));
+        onRawChunk(result.value);
         return pump(reader, res);
       });
   }

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -4,14 +4,7 @@ export default function mozXhrRequest(options) {
   const xhr = new XMLHttpRequest();
 
   function onProgressEvent() {
-    const view = new Uint8Array(xhr.response);
-    let len = view.length;
-
-    const rawString = new Array(len);
-    while(len--) {
-      rawString[len] = String.fromCharCode(view[len]);
-    }
-    options.onRawChunk(rawString.join(''));
+    options.onRawChunk(new Uint8Array(xhr.response));
   }
 
   function onLoadEvent() {

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -12,6 +12,7 @@ export default function xhrRequest(options) {
   }
 
   function onLoadEvent() {
+    // Force the textEncoder to flush.
     options.onRawChunk(textEncoder.encode(null, { stream: false }));
     options.onRawComplete({
       statusCode: xhr.status,

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -1,18 +1,18 @@
-import { uint8ArrayFromString } from '../util';
-
 export const XHR = 'xhr';
 
 export default function xhrRequest(options) {
+  const textEncoder = new TextEncoder();
   const xhr = new XMLHttpRequest();
   let index = 0;
 
   function onProgressEvent() {
     const rawText = xhr.responseText.substr(index);
     index = xhr.responseText.length;
-    options.onRawChunk(uint8ArrayFromString(rawText));
+    options.onRawChunk(textEncoder.encode(rawText, { stream: true }));
   }
 
   function onLoadEvent() {
+    options.onRawChunk(textEncoder.encode(null, { stream: false }));
     options.onRawComplete({
       statusCode: xhr.status,
       transport: XHR,

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -1,3 +1,5 @@
+import { uint8ArrayFromString } from '../util';
+
 export const XHR = 'xhr';
 
 export default function xhrRequest(options) {
@@ -5,9 +7,9 @@ export default function xhrRequest(options) {
   let index = 0;
 
   function onProgressEvent() {
-    const rawChunk = xhr.responseText.substr(index);
+    const rawText = xhr.responseText.substr(index);
     index = xhr.responseText.length;
-    options.onRawChunk(rawChunk);
+    options.onRawChunk(uint8ArrayFromString(rawText));
   }
 
   function onLoadEvent() {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,17 @@
+import { getBytesForCharCode, setBytesFromString } from 'utf-8';
+
 export function isObject(value) {
   return !!value && typeof value === 'object';
 }
 
 export  function noop() {
   /* No operation */
+}
+
+export function uint8ArrayFromString(str) {
+  let size = 0;
+  for (let i = 0, len = str.length; i < len; i++) {
+    size += getBytesForCharCode(str.charCodeAt(i))
+  }
+  return setBytesFromString(str, new Uint8Array(size), 0, size, true);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,3 @@
-import { getBytesForCharCode, setBytesFromString } from 'utf-8';
-
 export function isObject(value) {
   return !!value && typeof value === 'object';
 }
@@ -9,9 +7,11 @@ export  function noop() {
 }
 
 export function uint8ArrayFromString(str) {
-  let size = 0;
-  for (let i = 0, len = str.length; i < len; i++) {
-    size += getBytesForCharCode(str.charCodeAt(i))
-  }
-  return setBytesFromString(str, new Uint8Array(size), 0, size, true);
+  const encoder = new TextEncoder();
+  return encoder.encode(str);
+}
+
+export function stringFromUint8Array(arr) {
+  const decoder = new TextDecoder();
+  return decoder.decode(arr);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -5,13 +5,3 @@ export function isObject(value) {
 export  function noop() {
   /* No operation */
 }
-
-export function uint8ArrayFromString(str) {
-  const encoder = new TextEncoder();
-  return encoder.encode(str);
-}
-
-export function stringFromUint8Array(arr) {
-  const decoder = new TextDecoder();
-  return decoder.decode(arr);
-}

--- a/test/integ/.eslintrc.json
+++ b/test/integ/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "env": {
-    "browser": true,
     "jasmine": true
+  },
+  "rules": {
+    "no-console": 0
   }
 }

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -28,6 +28,21 @@ describe('chunked-request', () => {
     });
   });
 
+  it('should supply a Uint8Array to the chunkParser', done => {
+    let actual = false;
+
+    const onComplete = () => {
+      expect(actual).toBe(true);
+      done();
+    };
+
+    chunkedRequest({
+      url: `/chunked-response?numChunks=1&entriesPerChunk=1&delimitLast=1`,
+      chunkParser: bytes => { actual = (bytes instanceof Uint8Array); },
+      onComplete
+    });
+  });
+
   it('should parse utf8 responses', done => {
     const receivedChunks = [];
 

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -1,7 +1,8 @@
+import './polyfill';
 import chunkedRequest from '../../src/index';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
-import { getStringFromBytes } from 'utf-8';
+import { stringFromUint8Array } from '../../src/util';
 
 // These integration tests run through Karma; check `karma.conf.js` for
 // configuration.  Note that the dev-server which provides the `/chunked-response`
@@ -133,7 +134,7 @@ describe('chunked-request', () => {
       expect(chunkErrors.length).toBe(1, 'one errors caught');
       expect(chunkErrors[0].message).toBe('expected');
 
-      const rawChunkStr = getStringFromBytes(chunkErrors[0].chunkBytes);
+      const rawChunkStr = stringFromUint8Array(chunkErrors[0].chunkBytes);
       expect(rawChunkStr).toBe(`{ "chunk": "#1", "data": "#0" }\n`);
       
       done();

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -157,7 +157,7 @@ describe('chunked-request', () => {
     chunkedRequest({
       url: `/chunked-response?numChunks=1&entriesPerChunk=1&delimitLast=1`,
       chunkParser: (chunkBytes, state, flush) => {
-        if (!flush) {
+        if (chunkBytes.length > 0 && !flush) {
           throw new Error("expected");
         }
         return [];

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -1,4 +1,3 @@
-import './polyfill';
 import chunkedRequest from '../../src/index';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -1,7 +1,6 @@
 import chunkedRequest from '../../src/index';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
-import { stringFromUint8Array } from '../../src/util';
 
 // These integration tests run through Karma; check `karma.conf.js` for
 // configuration.  Note that the dev-server which provides the `/chunked-response`
@@ -148,7 +147,7 @@ describe('chunked-request', () => {
       expect(chunkErrors.length).toBe(1, 'one errors caught');
       expect(chunkErrors[0].message).toBe('expected');
 
-      const rawChunkStr = stringFromUint8Array(chunkErrors[0].chunkBytes);
+      const rawChunkStr = new TextDecoder().decode(chunkErrors[0].chunkBytes);
       expect(rawChunkStr).toBe(`{ "chunk": "#1", "data": "#0" }\n`);
       
       done();

--- a/test/integ/polyfill.js
+++ b/test/integ/polyfill.js
@@ -1,0 +1,9 @@
+import typedarray from 'typedarray';
+
+Object.keys(typedarray)
+  .forEach(k => {
+    if (!window[k]) {
+      console.log("=> Polyfilling " + k);
+      window[k] = typedarray[k];
+    }
+  });

--- a/test/integ/polyfill.js
+++ b/test/integ/polyfill.js
@@ -1,9 +1,0 @@
-import typedarray from 'typedarray';
-
-Object.keys(typedarray)
-  .forEach(k => {
-    if (!window[k]) {
-      console.log("=> Polyfilling " + k);
-      window[k] = typedarray[k];
-    }
-  });

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -66,6 +66,13 @@ function serveSplitChunkedResponse(req, res) {
   }, chunkIntervalMs);
 }
 
+function serveChunkedUtf8Response(req, res) {
+  res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+  res.setHeader('Transfer-Encoding', 'chunked');
+  res.write(JSON.stringify({ "message": "𝌆" }) + "\n");
+  res.end();
+}
+
 function serveChunkedResponse(req, res) {
   const query = url.parse(req.url, true).query;
   const numChunks = parseInt(query.numChunks, 10) || 4;
@@ -108,6 +115,8 @@ function handler(req, res) {
   switch (req.parsedUrl.pathname) {
   case '/chunked-response':
     return serveChunkedResponse(req, res);
+  case '/chunked-utf8-response':
+    return serveChunkedUtf8Response(req, res);
   case '/split-chunked-response':
     return serveSplitChunkedResponse(req, res);
   case '/echo-response':


### PR DESCRIPTION
- Request implementations now supply a `Uint8Array` of binary data through to the `chunkParser`.
- `defaultChunkParser` converts the `chunkBytes` into a string for processing
- Overhauled how parserState is handled; no longer assume that the `chunkParser` will emit a string; instead we use a `state` object whose contract is wholly owned by the parser (we just shuffle it around internally).
- Added test-coverage for UTF-8 characters
- Added dependency on `utf-8` lib for handling (un)marhsalling of binary data to text.
- Updated documentation
- Updated npm dependencies.

Inspiration provided by @mwitkow and @ariutta -- many thanks! :)
