### PR TITLE
Prevent fetch promise catching

### DIFF
--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -10,11 +10,14 @@ export default function fetchRequest(options) {
     return reader.read()
       .then(result => {
         if (result.done) {
-          return onRawComplete({
-            statusCode: res.status,
-            transport: READABLE_BYTE_STREAM,
-            raw: res
+          setTimeout(() => {
+            onRawComplete({
+              statusCode: res.status,
+              transport: READABLE_BYTE_STREAM,
+              raw: res
+            });
           });
+          return;
         }
         onRawChunk(result.value);
         return pump(reader, res);
@@ -22,10 +25,12 @@ export default function fetchRequest(options) {
   }
 
   function onError(err) {
-    options.onRawComplete({
-      statusCode: 0,
-      transport: READABLE_BYTE_STREAM,
-      raw: err
+    setTimeout(() => {
+      options.onRawComplete({
+        statusCode: 0,
+        transport: READABLE_BYTE_STREAM,
+        raw: err
+      });
     });
   }
 


### PR DESCRIPTION
This wraps the `onRawComplete` call in the `fetch` implementation with a `setTimeout` to prevent exceptions thrown by the callback function from being caught by the `fetch.catch()`.
