### PR TITLE
Exposing Headers (BrowserHeaders)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 lib/
 build/
 dist/
+webpack.config.js

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A function which implements the following interface:
 (headers, statusCode) => undefined
 ```
 
-A function which will be invoked once when the browser has returned the headers of the response. This function is invoked with two arguments:
+A function which will be invoked once when the browser has returned the headers of the response. This will be invoked *before* the first `onChunk` callback. This function is invoked with two arguments:
 
 * `headers` - An instance of [BrowserHeaders](https://github.com/improbable-eng/js-browser-headers)
 * `statusCode` - HTTP status code returned by the underlying transport

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ chunkedRequest({
   credentials: 'include',
   chunkParser(rawChunk) { /*...*/ },
   onChunk(err, parsedChunk) { /*...*/ },
+  onHeaders(headers, status) { /*...*/ }
   onComplete(result) { /*...*/ }
 });
 ```
@@ -74,6 +75,19 @@ A function which implements the following interface:
 ```
 
 The `onChunk` handler will be invoked each time a chunk of data it returned by the server. This function will be invoked one or more times depending on the response.  The function is invoked with two arguments; the first is an optional error which will be null unless there was a parsing error thrown by the `chunkParser``.  The second argument is an optional parsedChunk value which is produced by the supplied `chunkParser` (see: `options.chunkParser`).
+
+#### onHeaders (optional)
+A function which implements the following interface:
+
+```js
+(headers, statusCode) => undefined
+```
+
+A function which will be invoked once when the browser has returned the headers of the response. This function is invoked with two arguments:
+
+* `headers` - An instance of [BrowserHeaders](https://github.com/improbable-eng/js-browser-headers)
+* `statusCode` - HTTP status code returned by the underlying transport
+
 
 #### onComplete (optional)
 A function which implements the following interface:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -89,6 +89,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      '**/*.js': ['sourcemap']
     },
 
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "prepublish": "npm run clean && npm run build:lib",
     "clean": "rm -rf build/*",
-    "build:integ": "mkdir -p build && browserify test/integ/*.spec.js -o build/integration-tests.js --debug -t [ babelify ]",
+    "build:integ": "webpack",
     "build:lib": "mkdir -p lib && babel --out-dir lib src",
     "lint": "eslint .",
     "test": "npm run lint && npm run test:integ",
@@ -24,21 +24,25 @@
     "release": "./release.sh ${npm_package_version}"
   },
   "devDependencies": {
-    "babel-cli": "^6.11.4",
+    "babel-core": "^6.23.1",
+    "babel-loader": "^6.3.2",
     "babel-preset-es2015": "^6.13.2",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "cookie": "^0.3.1",
     "eslint": "^3.3.1",
-    "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
     "karma": "^1.2.0",
     "karma-chrome-launcher": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-sauce-launcher": "^1.0.0",
+    "karma-sourcemap-loader": "^0.3.7",
     "lodash": "^4.15.0",
     "text-encoding": "^0.6.0",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "webpack": "^2.2.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "browser-headers": "^0.1.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "release": "./release.sh ${npm_package_version}"
   },
   "devDependencies": {
+    "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
     "babel-loader": "^6.3.2",
     "babel-preset-es2015": "^6.13.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.1.5"
+    "browser-headers": "^0.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.1.3"
+    "browser-headers": "^0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.1.4"
+    "browser-headers": "^0.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.1.2"
+    "browser-headers": "^0.1.3"
   }
 }

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -38,8 +38,7 @@ export default function fetchRequest(options) {
 
   fetch(options.url, { headers, method, body, credentials })
     .then(res => {
-      const browserHeaders = new BrowserHeaders(res.headers);
-      options.onRawHeaders(browserHeaders, res.status);
+      options.onRawHeaders(new BrowserHeaders(res.headers), res.status);
       return pump(res.body.getReader(), res)
     })
     .catch(onError);

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -1,3 +1,5 @@
+import BrowserHeaders from 'browser-headers';
+
 import { isObject } from '../util';
 
 export const READABLE_BYTE_STREAM = 'readable-byte-stream';
@@ -30,7 +32,11 @@ export default function fetchRequest(options) {
   }
 
   fetch(options.url, { headers, method, body, credentials })
-    .then(res => pump(res.body.getReader(), res))
+    .then(res => {
+      const browserHeaders = new BrowserHeaders(res.headers);
+      options.onRawHeaders(browserHeaders, res.status);
+      return pump(res.body.getReader(), res)
+    })
     .catch(onError);
 }
 

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -1,3 +1,5 @@
+import BrowserHeaders from 'browser-headers';
+
 export const MOZ_CHUNKED = 'moz-chunked';
 
 export default function mozXhrRequest(options) {
@@ -15,6 +17,12 @@ export default function mozXhrRequest(options) {
     });
   }
 
+  function onStateChange() {
+    if(this.readyState == this.HEADERS_RECEIVED) {
+      const browserHeaders = new BrowserHeaders(this.getAllResponseHeaders());
+      options.onRawHeaders(browserHeaders, this.status);
+    }
+  }
   function onError(err) {
     options.onRawComplete({
       statusCode: 0,
@@ -33,6 +41,7 @@ export default function mozXhrRequest(options) {
   if (options.credentials === 'include') {
     xhr.withCredentials = true;
   }
+  xhr.addEventListener('readystatechange', onStateChange);
   xhr.addEventListener('progress', onProgressEvent);
   xhr.addEventListener('loadend', onLoadEvent);
   xhr.addEventListener('error', onError);

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -19,8 +19,7 @@ export default function mozXhrRequest(options) {
 
   function onStateChange() {
     if(this.readyState == this.HEADERS_RECEIVED) {
-      const browserHeaders = new BrowserHeaders(this.getAllResponseHeaders());
-      options.onRawHeaders(browserHeaders, this.status);
+      options.onRawHeaders(new BrowserHeaders(this.getAllResponseHeaders()), this.status);
     }
   }
   function onError(err) {

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -25,8 +25,7 @@ export default function xhrRequest(options) {
 
   function onStateChange() {
     if(this.readyState == this.HEADERS_RECEIVED) {
-      const browserHeaders = new BrowserHeaders(this.getAllResponseHeaders());
-      options.onRawHeaders(browserHeaders, this.status);
+      options.onRawHeaders(new BrowserHeaders(this.getAllResponseHeaders()), this.status);
     }
   }
 

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -1,3 +1,5 @@
+import BrowserHeaders from 'browser-headers';
+
 export const XHR = 'xhr';
 
 export default function xhrRequest(options) {
@@ -21,6 +23,13 @@ export default function xhrRequest(options) {
     });
   }
 
+  function onStateChange() {
+    if(this.readyState == this.HEADERS_RECEIVED) {
+      const browserHeaders = new BrowserHeaders(this.getAllResponseHeaders());
+      options.onRawHeaders(browserHeaders, this.status);
+    }
+  }
+
   function onError(err) {
     options.onRawComplete({
       statusCode: 0,
@@ -39,6 +48,7 @@ export default function xhrRequest(options) {
   if (options.credentials === 'include') {
     xhr.withCredentials = true;
   }
+  xhr.addEventListener('readystatechange', onStateChange);
   xhr.addEventListener('progress', onProgressEvent);
   xhr.addEventListener('loadend', onLoadEvent);
   xhr.addEventListener('error', onError);

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -74,6 +74,14 @@ describe('chunked-request', () => {
   it('should parse a response that consists of two chunks and ends with a delimiter', done => {
     const receivedChunks = [];
 
+    let onHeadersCalled = false;
+    let onChunkCalled = false;
+    const onHeaders = (headers, status) => {
+      expect(onChunkCalled).toBe(false, 'onChunk should not be called before onHeaders');
+      expect(status).toBe(200, 'status 200');
+      onHeadersCalled = true;
+    };
+
     const onComplete = () => {
       const chunkErrors = receivedChunks.filter(v => v instanceof Error);
 
@@ -91,8 +99,11 @@ describe('chunked-request', () => {
     chunkedRequest({
       url: `/chunked-response?numChunks=3&entriesPerChunk=1&delimitLast=1`,
       onChunk: (err, chunk) => {
+        expect(onHeadersCalled).toBe(true, 'onHeaders should be called before the first onChunk');
+        onChunkCalled = true;
         receivedChunks.push(err || chunk)
       },
+      onHeaders,
       onComplete
     });
   });

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -81,6 +81,7 @@ function serveChunkedResponse(req, res) {
 
   res.setHeader('Content-Type', 'text/html; charset=UTF-8');
   res.setHeader('Transfer-Encoding', 'chunked');
+  res.setHeader('My-Header', 'My-Header-Value');
 
   // Start at 1 as we serve the first chunk immediately.
   let i = 1;
@@ -104,7 +105,7 @@ function serveChunkedResponse(req, res) {
 }
 
 function serveErrorResponse(req, res) {
-  res.writeHead(500);
+  res.writeHead(500, {'My-Error-Header': 'My-Error-Header-Value'});
   res.write(JSON.stringify({ error: "internal" }));
   res.end();
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+module.exports = {
+  entry: "./test/integ/chunked-request.spec.js",
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: 'integration-tests.js',
+  },
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: /src|test|node_modules/,
+        loader: 'babel-loader?cacheDirectory'
+      }
+    ]
+  },
+  resolve: {
+    extensions: [".js"]
+  }
+};
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        include: /src|test|node_modules/,
+        include: /src|test/,
+        exclude: /node_modules/,
         loader: 'babel-loader?cacheDirectory'
       }
     ]


### PR DESCRIPTION
This PR introduces the first dependency (https://github.com/improbable-eng/js-browser-headers) in order to expose the `Headers` instance that `fetch` returns (or is created by parsing the headers as a string).

`BrowserHeaders` provides a consistent API between browsers, which is in keeping with the intention of this package which is to abstract the different implementations.

This PR also changes to using Webpack to build the tests and adds source map support so that you can see stack traces for the test failures.