### PR TITLE
Support for BrowserHeaders for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ The URL to make the request against as a string
 The HTTP method to use when making the request.
 
 #### headers (optional)
-A hash of HTTP headers to sent with the request.
+HTTP headers to sent with the request in the form of one of:
+* An instance of [BrowserHeaders](https://github.com/improbable-eng/js-browser-headers)
+* An instance of `Headers`
+* An object consisting of `string: (string|string[])` (e.g. `{"key-a":["one","two"],"key-b":"three"}`) 
+* A `Map<string, string|string[]>`
+* A CLRF-delimited string (e.g. `key-a: one\r\nkey-b: two`)
 
 #### body (optional)
 The value to send along with the request.
@@ -116,6 +121,8 @@ A function which implements the following interface:
 The underlying function used to make the request, see the provided implementations if you wish to provide a custom extension.  Note that you must supply a Uint8Array to the `onRawChunk` callback.
 
 If no value is supplied the `chunkedRequest.transportFactory` function will be invoked to determine which transport method to use.  The default `transportFactory` will attempt to select the best available method for the current platform; but you can override this method for substituting a test-double or custom implementation.
+
+The `headers` property is an instance of [BrowserHeaders](https://github.com/improbable-eng/js-browser-headers).
 
 
 ## Writing a Custom Chunk Parser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -118,6 +118,7 @@ module.exports = function(config) {
 
     browsers: browsers,
     captureTimeout: 120000,
+    browserNoActivityTimeout: 60000,
     customLaunchers: customLaunchers,
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.2.0"
+    "browser-headers": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.1.6"
+    "browser-headers": "^0.2.0"
   }
 }

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -1,12 +1,10 @@
-import BrowserHeaders from 'browser-headers';
-
-import { isObject } from '../util';
+import { BrowserHeaders } from 'browser-headers';
 
 export const READABLE_BYTE_STREAM = 'readable-byte-stream';
 
 export default function fetchRequest(options) {
   const { onRawChunk, onRawComplete, method, body, credentials } = options;
-  const headers = marshallHeaders(options.headers);
+  const headers = options.headers.toHeaders();
 
   function pump(reader, res) {
     return reader.read()
@@ -42,12 +40,4 @@ export default function fetchRequest(options) {
       return pump(res.body.getReader(), res)
     })
     .catch(onError);
-}
-
-function marshallHeaders(v) {
-  if (v instanceof Headers) {
-    return v;
-  } else if (isObject(v)) {
-    return new Headers(v);
-  }
 }

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -1,4 +1,4 @@
-import BrowserHeaders from 'browser-headers';
+import { BrowserHeaders } from 'browser-headers';
 
 export const MOZ_CHUNKED = 'moz-chunked';
 
@@ -32,11 +32,9 @@ export default function mozXhrRequest(options) {
 
   xhr.open(options.method, options.url);
   xhr.responseType = 'moz-chunked-arraybuffer';
-  if (options.headers) {
-    Object.getOwnPropertyNames(options.headers).forEach(k => {
-      xhr.setRequestHeader(k, options.headers[k]);
-    })
-  }
+  options.headers.forEach((key, values) => {
+    xhr.setRequestHeader(key, values.join(", "));
+  });
   if (options.credentials === 'include') {
     xhr.withCredentials = true;
   }

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -1,4 +1,4 @@
-import BrowserHeaders from 'browser-headers';
+import { BrowserHeaders } from 'browser-headers';
 
 export const XHR = 'xhr';
 
@@ -39,11 +39,9 @@ export default function xhrRequest(options) {
 
   xhr.open(options.method, options.url);
   xhr.responseType = 'text';
-  if (options.headers) {
-    Object.getOwnPropertyNames(options.headers).forEach(k => {
-      xhr.setRequestHeader(k, options.headers[k]);
-    })
-  }
+  options.headers.forEach((key, values) => {
+    xhr.setRequestHeader(key, values.join(", "));
+  });
   if (options.credentials === 'include') {
     xhr.withCredentials = true;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default function chunkedRequest(options) {
 
   transport({
     url,
-    headers: new BrowserHeaders(headers ? headers : {}),
+    headers: new BrowserHeaders(headers || {}),
     method,
     body,
     credentials,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { isObject, noop } from './util';
 import defaultTransportFactory  from './defaultTransportFactory';
 import defaultChunkParser from './defaultChunkParser';
+import { BrowserHeaders } from 'browser-headers';
 
 // chunkedRequest will make a network request to the URL specified in `options.url`
 // passing chunks of data extracted by the optional `options.chunkParser` to the
@@ -64,7 +65,7 @@ export default function chunkedRequest(options) {
 
   transport({
     url,
-    headers,
+    headers: new BrowserHeaders(headers ? headers : {}),
     method,
     body,
     credentials,


### PR DESCRIPTION
This PR adds support for passing an instance of [`BrowserHeaders`](https://github.com/improbable-eng/js-browser-headers) or any other headers format that `BrowserHeaders` can be constructed with. 

A (potentially empty) `BrowserHeaders` instance is then passed to the `transport` (therefore changing the API that alternative transports must implement). 

The `fetch` transport uses the new (`BrowserHeaders@0.2.0`) `.toHeaders()` function to convert the `BrowserHeaders` instance to a `Headers`, and the xhr-based transports iterate over the `BrowserHeaders` and set the headers individually.