### PR TITLE
Update BrowserHeaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.3.0"
+    "browser-headers": "^0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
-    "browser-headers": "^0.2.1"
+    "browser-headers": "^0.3.0"
   }
 }


### PR DESCRIPTION
Version `0.3.1` of `BrowserHeaders` contains a fix for the construction of `BrowserHeaders` from another instance of `BrowserHeaders`. 

This is required to simplify work on a library that uses `ChunkedRequest` that also has a direct dependency on `BrowserHeaders`. Under certain configurations this can result in two `BrowserHeaders` classes that cause usage of `instanceof` to be falsy.